### PR TITLE
export unsafeResponseStateTransition + authentication example

### DIFF
--- a/src/MiddlewareTask.ts
+++ b/src/MiddlewareTask.ts
@@ -126,9 +126,11 @@ export const status = (status: Status): ResponseStateTransition<StatusOpen, Head
 export const header = ([field, value]: Header): ResponseStateTransition<HeadersOpen, HeadersOpen> =>
   transition(c => c.res.header(field, value))
 
-export const closeHeaders: ResponseStateTransition<HeadersOpen, BodyOpen> = new MiddlewareTask(c =>
+export const unsafeResponseStateTransition: ResponseStateTransition<any, any> = new MiddlewareTask(c =>
   task.of([undefined, c] as any)
 )
+
+export const closeHeaders: ResponseStateTransition<HeadersOpen, BodyOpen> = unsafeResponseStateTransition
 
 export const send = (o: string): ResponseStateTransition<BodyOpen, ResponseEnded> => transition(c => c.res.send(o))
 


### PR DESCRIPTION
@OliverJAsh @sledorze This is an example showing how to ensure authentication statically. I think that there are other ways to do this, more sophisticated and that can handle authorization as well, but I guess this is just fine as a first attempt

```ts
import * as express from 'express'
import {
  status,
  closeHeaders,
  send,
  MiddlewareTask,
  param,
  of,
  Handler,
  unsafeResponseStateTransition
} from 'hyper-ts/lib/MiddlewareTask'
import { Status, StatusOpen } from 'hyper-ts'
import { Option, some, none } from 'fp-ts/lib/Option'
import * as t from 'io-ts'
import * as task from 'fp-ts/lib/Task'
import { tuple } from 'fp-ts/lib/function'
import { IntegerFromString } from 'io-ts-types/lib/number/IntegerFromString'

// the new connection state
type Authenticated = 'Authenticated'

interface Authentication
  extends MiddlewareTask<StatusOpen, StatusOpen, Option<MiddlewareTask<StatusOpen, Authenticated, void>>> {}

const withAuthentication = (strategy: (req: express.Request) => task.Task<boolean>): Authentication =>
  new MiddlewareTask(c => {
    return strategy(c.req).map(authenticated => tuple(authenticated ? some(unsafeResponseStateTransition) : none, c))
  })

// dummy authentication process
const tokenAuthentication = withAuthentication(req => task.of(t.string.is(req.get('token'))))

// dummy ResponseStateTransition (like closeHeaders)
const authenticated: MiddlewareTask<Authenticated, StatusOpen, void> = unsafeResponseStateTransition

//
// error handling combinators
//

const badRequest = (message: string) =>
  status(Status.BadRequest)
    .ichain(() => closeHeaders)
    .ichain(() => send(message))

const notFound = (message: string) =>
  status(Status.NotFound)
    .ichain(() => closeHeaders)
    .ichain(() => send(message))

const unauthorized = (message: string) =>
  status(Status.Unauthorized)
    .ichain(() => closeHeaders)
    .ichain(() => send(message))

//
// user
//

interface User {
  name: string
}

// the result of this function requires a successful authentication upstream
const loadUser = (id: number) => authenticated.ichain(() => of(id === 1 ? some<User>({ name: 'Giulio' }) : none))

const getUserId = param('user_id', IntegerFromString)

const sendUser = (user: User) =>
  status(Status.OK)
    .ichain(() => closeHeaders)
    .ichain(() => send(`Hello ${user.name}!`))

const user: Handler = getUserId.ichain(oid =>
  oid.fold(
    () => badRequest('Invalid user id'),
    id =>
      tokenAuthentication.ichain(oAuthenticated =>
        oAuthenticated.fold(
          () => unauthorized('Unauthorized user'),
          authenticated =>
            authenticated.ichain(() => loadUser(id).ichain(ou => ou.fold(() => notFound('User not found'), sendUser)))
        )
      )
  )
)

const app = express()
app.get('/:user_id', user.toRequestHandler())
app.listen(3000, () => console.log('App listening on port 3000!'))
```