### PR TITLE
use koa-bodyparser to provide access to request body

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
   "peerDependencies": {
     "@types/express": "4.11.0",
     "@types/koa": "^2.0.43",
+    "@types/koa-bodyparser": "^4.2.0",
     "express": "^4.16.2",
-    "koa": "^2.4.1"
+    "koa": "^2.4.1",
+    "koa-bodyparser": "^4.2.0"
   },
   "tags": [
     "typescript",

--- a/src/adapters/koa.ts
+++ b/src/adapters/koa.ts
@@ -16,7 +16,7 @@ export class KoaConn<S> implements Conn<S> {
   }
 
   public getBody() {
-    return this.context.body
+    return this.context.request.body
   }
 
   public getHeader(name: string) {


### PR DESCRIPTION
Hi Giulio 

I've been using this a little bit today, it's all working great except that the earlier version's `getBody` function on `KoaConn` was referring to the response body, not the request body. I've added a peer dep to the standard `koa-bodyparser` package which provides access the request body.